### PR TITLE
Fix: Missing parseInt on score comparison

### DIFF
--- a/src/lib/components/Popupbattle.svelte
+++ b/src/lib/components/Popupbattle.svelte
@@ -26,7 +26,7 @@
             </div>
 
             <p class="text-white text-xs text-center italic font-bold uppercase mt-1">
-                {#if profile_user_1.stat.score > profile_user_2.stat.score}
+                {#if parseInt(profile_user_1.stat.score) > parseInt(profile_user_2.stat.score)}
                     Won the DIFF battel against <span class="text-yellow-400 bg-orange-900 px-2 py-0.5 rounded-full mt-5">{ profile_user_2.nickname}</span>
                 {:else}
                     Won the DIFF battel against <span class="text-yellow-400 bg-orange-900 px-2 py-0.5 rounded-full mt-5">{profile_user_1.nickname}</span>


### PR DESCRIPTION
Because of this missing parseInt, the score comparison is done based on the strings instead of the int value.
As a result, in a diff between Dvorhack (12165 pts) and mouthon (8565 pts), Dvorhack wins the diff battle against himself.
Poc: https://root-me-diff.vercel.app/diff?user_1=mouthon-396365&user_2=Viel